### PR TITLE
Get historical panel data

### DIFF
--- a/src/solaredgeoptimizers/solaredgeoptimizers.py
+++ b/src/solaredgeoptimizers/solaredgeoptimizers.py
@@ -86,7 +86,7 @@ class solaredgeoptimizers:
 
         return data
 
-    def _doPostRequest(self, request_url, data=None):
+    def _doRequest(self, method, request_url, data=None):
         session = Session()
         session.head(
             "https://monitoring.solaredge.com/solaredge-apigw/api/sites/{}/layout/energy".format(
@@ -107,7 +107,8 @@ class solaredgeoptimizers:
         thecrsftoken = self.GetThecsrfToken(session.cookies.get_dict())
 
         # Build up the request.
-        response = session.post(
+        response = session.request(
+            method=method,
             url=request_url,
             headers={
                 "authority": "monitoring.solaredge.com",
@@ -142,7 +143,7 @@ class solaredgeoptimizers:
         url = "https://monitoring.solaredge.com/solaredge-apigw/api/sites/{}/layout/energy?timeUnit=ALL".format(
             self.siteid
         )
-        return self._doPostRequest(url)
+        return self._doRequest("POST", url)
 
     def getAlerts(self, only_open=False):
         # Note: this might require FULL_ACCESS rights in the SE portal, as opposed to DASHBOARD_AND_LAYOUT
@@ -154,7 +155,7 @@ class solaredgeoptimizers:
             data = [{"fieldFilterOperator": "IN",
                      "fieldName": "status",
                      "fieldValue": ["OPEN"]}]
-        return self._doPostRequest(url, data=json.dumps(data))
+        return self._doRequest("POST", url, data=json.dumps(data))
 
     def GetThecsrfToken(self, cookies):
         for cookie in cookies:

--- a/src/solaredgeoptimizers/solaredgeoptimizers.py
+++ b/src/solaredgeoptimizers/solaredgeoptimizers.py
@@ -86,7 +86,7 @@ class solaredgeoptimizers:
 
         return data
 
-    def _doPostRequest(self, request_url):
+    def _doPostRequest(self, request_url, data=None):
         session = Session()
         session.head(
             "https://monitoring.solaredge.com/solaredge-apigw/api/sites/{}/layout/energy".format(
@@ -130,6 +130,7 @@ class solaredgeoptimizers:
                 "x-kl-ajax-request": "Ajax_Request",
                 "x-requested-with": "XMLHttpRequest",
             },
+            data=data
         )
 
         if response.status_code == 200:
@@ -143,12 +144,17 @@ class solaredgeoptimizers:
         )
         return self._doPostRequest(url)
 
-    def getAlerts(self):
+    def getAlerts(self, only_open=False):
         # Note: this might require FULL_ACCESS rights in the SE portal, as opposed to DASHBOARD_AND_LAYOUT
         url = "https://monitoring.solaredge.com/solaredge-apigw/api/rna/v1.0/site/{}/alerts".format(
             self.siteid
         )
-        return self._doPostRequest(url)
+        data = None
+        if only_open:
+            data = [{"fieldFilterOperator": "IN",
+                     "fieldName": "status",
+                     "fieldValue": ["OPEN"]}]
+        return self._doPostRequest(url, data=json.dumps(data))
 
     def GetThecsrfToken(self, cookies):
         for cookie in cookies:

--- a/src/solaredgeoptimizers/solaredgeoptimizers.py
+++ b/src/solaredgeoptimizers/solaredgeoptimizers.py
@@ -86,7 +86,7 @@ class solaredgeoptimizers:
 
         return data
 
-    def getLifeTimeEnergy(self):
+    def _doPostRequest(self, request_url):
         session = Session()
         session.head(
             "https://monitoring.solaredge.com/solaredge-apigw/api/sites/{}/layout/energy".format(
@@ -108,9 +108,7 @@ class solaredgeoptimizers:
 
         # Build up the request.
         response = session.post(
-            url="https://monitoring.solaredge.com/solaredge-apigw/api/sites/{}/layout/energy?timeUnit=ALL".format(
-                self.siteid
-            ),
+            url=request_url,
             headers={
                 "authority": "monitoring.solaredge.com",
                 "accept": "*/*",
@@ -138,6 +136,19 @@ class solaredgeoptimizers:
             return response.text
         else:
             return "ERROR001 - HTTP CODE: {}".format(response.status_code)
+
+    def getLifeTimeEnergy(self):
+        url = "https://monitoring.solaredge.com/solaredge-apigw/api/sites/{}/layout/energy?timeUnit=ALL".format(
+            self.siteid
+        )
+        return self._doPostRequest(url)
+
+    def getAlerts(self):
+        # Note: this might require FULL_ACCESS rights in the SE portal, as opposed to DASHBOARD_AND_LAYOUT
+        url = "https://monitoring.solaredge.com/solaredge-apigw/api/rna/v1.0/site/{}/alerts".format(
+            self.siteid
+        )
+        return self._doPostRequest(url)
 
     def GetThecsrfToken(self, cookies):
         for cookie in cookies:


### PR DESCRIPTION
Implemented the retrieval of historical panel values between starttime and endtime (either datetime.datetime type or unix timestamp in ms, or None for default today)
```
requestHistoricalData(self, starttime=None, endtime=None, parameter="Power")
```
You can choose parameter from `{"Power", "Current", "Voltage", "Energy", "PowerBox Voltage"}`. It returns a dictionary of type Dict[SolarlEdgeOptimizer, Dict[datetime, float]].

This solves issue #6 .

Turns out that your means of authenticating, and administration of cookies works perfectly well also for this GET request. Hence I took the liberty to generalize your request function further to include all request-methods.
In my initial attempts I missed that my timestamps were formatted as floats rather than ints, which was not accepted by the SE portal.